### PR TITLE
Add provides command + sort help command

### DIFF
--- a/commands/docker/docker.yaml
+++ b/commands/docker/docker.yaml
@@ -1,0 +1,10 @@
+---
+
+- command: "docker"
+  name: "List docker commands"
+  description: "List docker related commands"
+  provides:
+    - commands/docker/image_list.yaml
+    - commands/docker/ps.yaml
+
+...

--- a/commands/gitlab/gitlab.yaml
+++ b/commands/gitlab/gitlab.yaml
@@ -1,0 +1,9 @@
+---
+
+- command: "gitlab"
+  name: "List gitlab commands"
+  description: "List gitlab related commands"
+  provides:
+    - commands/gitlab/upgrade_check.yaml
+
+...

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,9 +3,8 @@
 listen: "0.0.0.0:8080"
 token: "TOKEN"
 commands:
-  - commands/gitlab/upgrade_check.yaml
-  - commands/docker/image_list.yaml
-  - commands/docker/ps.yaml
+  - commands/gitlab/gitlab.yaml
+  - commands/docker/docker.yaml
 scheduler:
   - name: "Check Gitlab Version"
     command: "gitlab upgrade check"

--- a/server/server.go
+++ b/server/server.go
@@ -73,6 +73,9 @@ func hookHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			LogError("Error occurred while executing command! %v", err)
 			WriteErrorResponse(w, NewError("Command execution failed!", err))
 		} else if len(opsCommand.Provides) > 0 {
+			sort.Slice(opsCommand.ProvidedCommands, func(i, j int) bool {
+				return opsCommand.ProvidedCommands[i].Command < opsCommand.ProvidedCommands[j].Command
+			})
 			msg := "| Command | Slash Command | Description |\n| :-- | :-- | :-- |"
 			for _, c := range opsCommand.ProvidedCommands {
 				if opsCommand.CanTrigger(command.Username) {

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/go-co-op/gocron"
@@ -42,12 +43,19 @@ func hookHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	}
 	LogInfo("Received command: %s at channel %s from %s", command.Text, command.ChannelName, command.Username)
 	if command.Text == "" || command.Text == "help" {
-		msg := "| Command | Slash Command | Description |\n| :-- | :-- | :-- |"
-		for key, opsCommand := range Commands {
-			if opsCommand.CanTrigger(command.Username) {
-				msg += fmt.Sprintf("\n| __%s__ | `%s %s` | *%s* |", opsCommand.Name, command.Command, key, opsCommand.Description)
-			}
+		// lets sort the commands
+		keys := make([]string, 0, len(Commands))
+		for key := range Commands {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
 
+		msg := "| Command | Slash Command | Description |\n| :-- | :-- | :-- |"
+		for key := range keys {
+			opsCommand := Commands[keys[key]]
+			if opsCommand.CanTrigger(command.Username) {
+				msg += fmt.Sprintf("\n| __%s__ | `%s %s` | *%s* |", opsCommand.Name, command.Command, keys[key], opsCommand.Description)
+			}
 		}
 		WriteEnrichedResponse(w, "Supported Commands", msg, "#0000ff", model.CommandResponseTypeEphemeral)
 	} else {
@@ -64,6 +72,14 @@ func hookHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		if err != nil {
 			LogError("Error occurred while executing command! %v", err)
 			WriteErrorResponse(w, NewError("Command execution failed!", err))
+		} else if len(opsCommand.Provides) > 0 {
+			msg := "| Command | Slash Command | Description |\n| :-- | :-- | :-- |"
+			for _, c := range opsCommand.ProvidedCommands {
+				if opsCommand.CanTrigger(command.Username) {
+					msg += fmt.Sprintf("\n| __%s__ | `%s %s` | *%s* |", c.Name, command.Command, c.Command, c.Description)
+				}
+			}
+			WriteEnrichedResponse(w, opsCommand.Name, msg, "#0000ff", model.CommandResponseTypeEphemeral)
 		} else if opsCommand.Response.Generate {
 			msgColor := "#000000"
 			for _, responseColor := range opsCommand.Response.Colors {


### PR DESCRIPTION
#### Summary
This PR adds the ability for a command to be a "provider". A provider lists files that have to be included and creates a submenu.

Example:

<img width="897" alt="image" src="https://user-images.githubusercontent.com/785518/175406930-3d243c0b-8aba-4469-a826-6cdd6424968a.png">

In the future we can imagine inheriting some values from the provider to the children (example: Gitlab token)


