### PR TITLE
Panic is not fun

### DIFF
--- a/server/request.go
+++ b/server/request.go
@@ -39,10 +39,10 @@ func SendViaIncomingHook(hook, title, text, color string) {
 	response, error := client.Do(request)
 	if error != nil {
 		LogError("[%s]Error occured while sending data to %s. %v", title, hook, error)
+		return
 	}
 
 	if response.StatusCode != 200 {
 		LogError("[%s]Got %d while invoking %s.", title, response.StatusCode, hook)
 	}
-
 }


### PR DESCRIPTION
#### Summary
I got a panic with the scheduled fun (which was not fun 😱), the issue being that if the Incoming webhook fails (in my case, because the incoming webhook URL was not set), the response variable would be nil and panic. Returning upon getting the err fix the issue.

