### PR TITLE
Variables inheritance

### DIFF
--- a/commands/gitlab/gitlab.yaml
+++ b/commands/gitlab/gitlab.yaml
@@ -3,6 +3,11 @@
 - command: "gitlab"
   name: "List gitlab commands"
   description: "List gitlab related commands"
+  vars:
+    - name: GITLAB_URL
+      value: https://git.internal.mattermost.com
+    - name: GITLAB_TOKEN
+      value: TOKEN
   provides:
     - commands/gitlab/gitlab_version.yaml
     - commands/gitlab/gitlab_runners.yaml

--- a/commands/gitlab/gitlab_pipelines.yaml
+++ b/commands/gitlab/gitlab_pipelines.yaml
@@ -5,10 +5,6 @@
   name: "mattermost-server Pipelines"
   description: "Get paged pipelines of mattermost-server ascending. Please provide page number as argument to get old executions.`/ops gitlab pipelines mattermost-server 2`"
   vars:
-    - name: GITLAB_URL
-      value: https://git.internal.mattermost.com
-    - name: GITLAB_TOKEN
-      value: TOKEN
     - name: REPO_ID
       value: 163
   exec: 
@@ -33,10 +29,6 @@
   name: "mattermost-server jobs"
   description: "Get jobs of mattermost-server pipeline. `/ops gitlab jobs mattermost-server [pipeline_id]`"
   vars:
-    - name: GITLAB_URL
-      value: https://git.internal.mattermost.com
-    - name: GITLAB_TOKEN
-      value: TOKEN
     - name: REPO_ID
       value: 163
   exec: 
@@ -61,10 +53,6 @@
   name: "mattermost-server job log"
   description: "Get log of mattermost-server pipeline job log. `/ops gitlab log mattermost-server [job_id]`"
   vars:
-    - name: GITLAB_URL
-      value: https://git.internal.mattermost.com
-    - name: GITLAB_TOKEN
-      value: TOKEN
     - name: REPO_ID
       value: 163
   exec: 

--- a/commands/gitlab/gitlab_runners.yaml
+++ b/commands/gitlab/gitlab_runners.yaml
@@ -3,11 +3,6 @@
 - command: "runners"
   name: "List all Gitlab runners"
   description: "Lists all GitLab runners with tags."
-  vars:
-    - name: GITLAB_URL
-      value: https://git.internal.mattermost.com
-    - name: GITLAB_TOKEN
-      value: TOKEN
   exec: 
     - scripts/gitlab/gitlab_runners.sh
   response:

--- a/commands/gitlab/gitlab_version.yaml
+++ b/commands/gitlab/gitlab_version.yaml
@@ -3,11 +3,6 @@
 - command: "version"
   name: "Get GitLab Version"
   description: "Gets gitlab version. `gitlab version check` will do upgrade check!"
-  vars:
-    - name: GITLAB_URL
-      value: https://git.internal.mattermost.com
-    - name: GITLAB_TOKEN
-      value: TOKEN
   exec: 
     - scripts/gitlab/gitlab_version.sh
   response:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )
@@ -43,6 +45,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/xid v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/stretchr/testify v1.7.5
 	github.com/tinylib/msgp v1.1.6 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1263,6 +1263,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1271,7 +1272,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedup(t *testing.T) {
+	assert := require.New(t)
+
+	res := dedup([]OpsCommandVariable{
+		{Name: "a", Value: "va"},
+		{Name: "b", Value: "vb"},
+		{Name: "a", Value: "va2"},
+		{Name: "c", Value: "vc"},
+	})
+
+	assert.Len(res, 3)
+	assert.Equal("va2", res[0].Value)
+	assert.Equal("vb", res[1].Value)
+	assert.Equal("vc", res[2].Value)
+}

--- a/server/request.go
+++ b/server/request.go
@@ -32,13 +32,17 @@ func GenerateIncomingWebhookRequest(title, text, color string) []byte {
 func SendViaIncomingHook(hook, title, text, color string) {
 	data := GenerateIncomingWebhookRequest(title, text, color)
 
-	request, error := http.NewRequest("POST", hook, bytes.NewBuffer(data))
+	request, err := http.NewRequest("POST", hook, bytes.NewBuffer(data))
+	if err != nil {
+		LogError("[%s]Error occurred creating request to %s. %v", title, hook, err)
+		return
+	}
 	request.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	client := &http.Client{}
-	response, error := client.Do(request)
-	if error != nil {
-		LogError("[%s]Error occured while sending data to %s. %v", title, hook, error)
+	response, err := client.Do(request)
+	if err != nil {
+		LogError("[%s]Error occurred while sending data to %s. %v", title, hook, err)
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -112,7 +112,7 @@ func providerCommandHookHandler(slashCommand *MMSlashCommand, providerName strin
 	if opsCommand.Response.Generate {
 		msgColor := "#000000"
 		for _, responseColor := range opsCommand.Response.Colors {
-			if responseColor.Status == "" || responseColor.Status == output.Status { // Suport default color
+			if responseColor.Status == "" || responseColor.Status == output.Status { // Support default color
 				msgColor = responseColor.Color
 				break
 			}
@@ -131,7 +131,6 @@ func providerCommandHookHandler(slashCommand *MMSlashCommand, providerName strin
 		}, nil
 	}
 	return nil, nil
-
 }
 
 func hookHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -147,11 +146,13 @@ func hookHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	LogInfo("Received command: %s at channel %s from %s", slashCommand.Text, slashCommand.ChannelName, slashCommand.Username)
 	parsedCommand := strings.Fields(strings.TrimSpace(slashCommand.Text))
 	var response *HookResponse
-	if len(parsedCommand) == 0 {
+
+	switch len(parsedCommand) {
+	case 0:
 		response, err = helpHookHandler(slashCommand)
-	} else if len(parsedCommand) == 1 {
+	case 1:
 		response, err = providerHelpHookHandler(slashCommand, parsedCommand[0])
-	} else {
+	default:
 		response, err = providerCommandHookHandler(slashCommand, parsedCommand[0], parsedCommand[1], parsedCommand[2:])
 	}
 
@@ -223,5 +224,4 @@ func Start() {
 	if err := http.ListenAndServe(Config.Listen, router); err != nil {
 		LogError(err.Error())
 	}
-
 }


### PR DESCRIPTION
This PR allows parent variables to be inherited by child commands

Something to consider: If we decide to move the injection of `os.Environ()` AFTER we inject the command variables, then we could have the server local variable take precedence over the ones in the files. I don't know if you guys have a preference, this could be changed in a later PR if needed. Here's the code we would change for reference: https://github.com/mattermost/ops-tool/blob/6f18f65ec0bac6f34faa0883271ba41003b76519/server/command.go#L77-L84
Basically the first line of this block would move after the loop at the end of the block.

Bonus:

I also made some changes to make the linter (`make lint`) happy with our code (mostly changing a few if/else to switch