### PR TITLE
Plugins are not built and included in the Docker Image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,7 @@
-# This dockerfile is used to build Mattermost ops-tool
+# This dockerfile is used to build Mattermost ops-tool will all plugins.
+# See makefile to configure plugins
 # A multi stage build, with golang used as a builder
-# and gcr.io/distroless/static as runner
+# and dockerhub.io/debian:bullseye-20220801 as runner
 ARG GO_IMAGE=golang:1.18@sha256:90c06f42c1aa2b6b96441c0e6192aff48815cf5e7950cd661ed316fdbfb06ed4
 # hadolint ignore=DL3006
 FROM ${GO_IMAGE} as builder
@@ -13,10 +14,10 @@ COPY . /src
 WORKDIR /src
 RUN make go-build
 
-# Shrink final image since we only need the ops-tool binary
-# and use distroless container image as runner for security
-FROM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f as runner
+# Cause of bash plugins we need to execute bash and shell commands.
+FROM docker.io/debian:bullseye-20220801@sha256:82bab30ed448b8e2509aabe21f40f0607d905b7fd0dec72802627a20274eba55 as runner
 COPY --from=builder /src/dist/ops_tool-linux-amd64 /opt/ops-tool/bin/ops-tool
+COPY --from=builder /src/dist/plugins /opt/ops-tool/plugins
 
 # We should refrain from running as privileged user
 # Run as UID for nobody

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -4,7 +4,7 @@ listen: "0.0.0.0:8080"
 base_url: "https://op-tools-address.com"
 plugins:
   - name: bash_useful
-    file: plugins/bash.so
+    file: dist/plugins/bash.so
     config:
       files:
         - commands/gitlab/gitlab.yaml
@@ -12,7 +12,7 @@ plugins:
         - commands/k8s/k8s.yaml
         - commands/release/release.yaml
   - name: bash_fun
-    file: plugins/bash.so
+    file: dist/plugins/bash.so
     config:
       files:
         - commands/helloworld/helloworld.yaml

--- a/plugin/bash/Makefile
+++ b/plugin/bash/Makefile
@@ -1,0 +1,83 @@
+# ====================================================================================
+# Variables
+
+## General Variables
+APP_NAME    := ops-tool-bash-plugin
+
+# Get current date and format like: 2022-04-27 11:32
+BUILD_DATE  := $(shell date +%Y-%m-%d\ %H:%M)
+
+## General Configuration Variables
+# We don't need make's built-in rules.
+MAKEFLAGS     += --no-builtin-rules
+# Be pedantic about undefined variables.
+MAKEFLAGS     += --warn-undefined-variables
+# Set help as default target
+.DEFAULT_GOAL := help
+
+# App Code location
+CONFIG_APP_CODE         += ./
+
+## Go Variables
+# Go executable
+GO                           := $(shell which go)
+# Extract GO version from go.mod file
+GO_VERSION                   ?= $(shell grep -E '^go' go.mod | awk {'print $$2'})
+# Build options
+GO_BUILD_OPTS                := -mod=readonly -trimpath -buildmode=plugin
+GO_TEST_OPTS                 := -mod=readonly -failfast -race
+# Plugin generation dir
+GO_OUT_SO_PATH               := ../../dist/plugins/bash.so
+
+# ====================================================================================
+# Colors
+
+BLUE   := $(shell printf "\033[34m")
+YELLOW := $(shell printf "\033[33m")
+RED    := $(shell printf "\033[31m")
+GREEN  := $(shell printf "\033[32m")
+CYAN   := $(shell printf "\033[36m")
+CNone  := $(shell printf "\033[0m")
+
+# ====================================================================================
+# Logger
+
+TIME_LONG	= `date +%Y-%m-%d' '%H:%M:%S`
+TIME_SHORT	= `date +%H:%M:%S`
+TIME		= $(TIME_SHORT)
+
+INFO = echo ${TIME} ${BLUE}[ .. ]${CNone}
+WARN = echo ${TIME} ${YELLOW}[WARN]${CNone}
+ERR  = echo ${TIME} ${RED}[FAIL]${CNone}
+OK   = echo ${TIME} ${GREEN}[ OK ]${CNone}
+FAIL = (echo ${TIME} ${RED}[FAIL]${CNone} && false)
+
+# ====================================================================================
+# Verbosity control hack
+
+VERBOSE ?= 0
+AT_0 := @
+AT_1 :=
+AT = $(AT_$(VERBOSE))
+
+# ====================================================================================
+# Targets
+
+help: ## to get help
+	@echo "Usage:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
+	awk 'BEGIN {FS = ":.*?## "}; {printf "make ${CYAN}%-30s${CNone} %s\n", $$1, $$2}'
+
+.PHONY: build
+build: ## to build plugin
+	@$(INFO) go build 
+	$(AT)$(GO) build ${GO_BUILD_OPTS} \
+	-o ${GO_OUT_SO_PATH} \
+	${CONFIG_APP_CODE} || ${FAIL}
+	@$(OK) go build $*
+
+.PHONY: test
+test: ## to test plugin
+	@$(INFO) testing...
+	$(AT)$(GO) test ${GO_TEST_OPTS} ./...  || ${FAIL}
+	@$(OK) testing


### PR DESCRIPTION
#### Summary
We enabled plugin support for OpsTool. But those images were not included in the builds and generating containers. Cause of it we are generating unusable docker images.

PR contains changes to build every plugin and include them in the container.

Plugin artifacts will be stored under `dist/plugins` folder. 

To configure a plugin in the builds:
1. Create a makefile in the plugin folder and add build target which generates artifact at ../../dist/plugins` folder.
2. Modify main Makefile and add plugin name to the `OPS_TOOL_PLUGINS` list.

#### CGO_ENABLED=1
We started to build with CGO_ENABLED cause plugin builds needs that configuration since plugins requires dynamic linker. 
Details are here: https://github.com/golang/go/issues/19569

#### Docker image change
At Distroless image bash is not installed and our bash plugin fails. To make bash plugin work and not build docker image frequently (cause of bash plugin and command needs), changed runner base image to debian.

#### Ticket Link
Fixes #35 

