### PR TITLE
Add access control at the command level

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/mattermost/ops-tool/model"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -36,12 +37,13 @@ type PluginConfig struct {
 }
 
 type CommandConfig struct {
-	Command              string          `yaml:"command"`
-	Token                string          `yaml:"token"`
-	DialogURL            string          `yaml:"dialog_url"`
-	DialogResponseURL    string          `yaml:"dialog_response_url"`
-	SchedulerResponseURL string          `yaml:"scheduler_response_url"`
-	Plugins              []CommandPlugin `yaml:"plugins"`
+	Command              string              `yaml:"command"`
+	Token                string              `yaml:"token"`
+	DialogURL            string              `yaml:"dialog_url"`
+	DialogResponseURL    string              `yaml:"dialog_response_url"`
+	SchedulerResponseURL string              `yaml:"scheduler_response_url"`
+	Plugins              []CommandPlugin     `yaml:"plugins"`
+	AccessControl        model.AccessControl `yaml:"access_control"`
 }
 
 type ScheduledCommandConfig struct {

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -29,6 +29,10 @@ commands:
     dialog_url: https://my-mattermost-instance.cloud.mattermost.com/api/v4/actions/dialogs/open
     dialog_response_url: https://my-mattermost-instance.cloud.mattermost.com/hooks/random-id
     scheduler_response_url:  https://my-mattermost-instance.cloud.mattermost.com/hooks/random-id
+    access_control:
+      team_name: ["team-name"]
+      channel_id: ["channel-id"]
+      user_name: ["user1", "user2"]
 scheduler:
   - name: "Check Gitlab Version"
     command: "jops gitlab version --check"

--- a/model/access_control.go
+++ b/model/access_control.go
@@ -1,0 +1,15 @@
+package model
+
+type AccessControl struct {
+	TeamID      []string `yaml:"team_id"`
+	TeamName    []string `yaml:"team_name"`
+	ChannelID   []string `yaml:"channel_id"`
+	ChannelName []string `yaml:"channel_name"`
+	UserID      []string `yaml:"user_id"`
+	UserName    []string `yaml:"user_name"`
+}
+
+// return true if all rules are empty
+func (a *AccessControl) IsEmpty() bool {
+	return len(a.TeamID) == 0 && len(a.TeamName) == 0 && len(a.ChannelID) == 0 && len(a.ChannelName) == 0 && len(a.UserID) == 0 && len(a.UserName) == 0
+}

--- a/model/access_control_test.go
+++ b/model/access_control_test.go
@@ -1,0 +1,94 @@
+package model
+
+import "testing"
+
+func TestAccessControl_IsEmpty(t *testing.T) {
+	type fields struct {
+		TeamID      []string
+		TeamName    []string
+		ChannelID   []string
+		ChannelName []string
+		UserID      []string
+		UserName    []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name:   "empty",
+			fields: fields{},
+			want:   true,
+		},
+		{
+			name: "full",
+			fields: fields{
+				TeamID:      []string{"1"},
+				TeamName:    []string{"2"},
+				ChannelID:   []string{"3"},
+				ChannelName: []string{"4"},
+				UserID:      []string{"5"},
+				UserName:    []string{"6"},
+			},
+			want: false,
+		},
+		{
+			name: "team id not empty",
+			fields: fields{
+				TeamID: []string{"1"},
+			},
+			want: false,
+		},
+		{
+			name: "team name not empty",
+			fields: fields{
+				TeamName: []string{"2"},
+			},
+			want: false,
+		},
+		{
+			name: "channel id not empty",
+			fields: fields{
+				ChannelID: []string{"3"},
+			},
+			want: false,
+		},
+		{
+			name: "channel name not empty",
+			fields: fields{
+				ChannelName: []string{"4"},
+			},
+			want: false,
+		},
+		{
+			name: "user id not empty",
+			fields: fields{
+				UserID: []string{"5"},
+			},
+			want: false,
+		},
+		{
+			name: "user name not empty",
+			fields: fields{
+				UserName: []string{"6"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AccessControl{
+				TeamID:      tt.fields.TeamID,
+				TeamName:    tt.fields.TeamName,
+				ChannelID:   tt.fields.ChannelID,
+				ChannelName: tt.fields.ChannelName,
+				UserID:      tt.fields.UserID,
+				UserName:    tt.fields.UserName,
+			}
+			if got := a.IsEmpty(); got != tt.want {
+				t.Errorf("AccessControl.IsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/scheduled.go
+++ b/server/scheduled.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-co-op/gocron"
 	"github.com/mattermost/ops-tool/config"
 	"github.com/mattermost/ops-tool/log"
-	"github.com/mattermost/ops-tool/model"
 )
 
 func (s *Server) scheduledCommandHandler(scheduledCommand config.ScheduledCommandConfig, job gocron.Job) {
@@ -27,7 +26,7 @@ func (s *Server) scheduledCommandHandler(scheduledCommand config.ScheduledComman
 		return
 	}
 
-	response, err := cmd.Execute(ctx, &model.MMSlashCommand{}, cmdText, args)
+	response, err := cmd.Execute(ctx, nil, cmdText, args)
 	if err != nil {
 		log.Printf("error executing command: %s", err.Error())
 		return

--- a/slashcommand/slashcommand_test.go
+++ b/slashcommand/slashcommand_test.go
@@ -1,0 +1,172 @@
+package slashcommand
+
+import (
+	"testing"
+
+	"github.com/mattermost/ops-tool/model"
+)
+
+func TestSlashCommand_accessControl(t *testing.T) {
+	mmSlashCommand := &model.MMSlashCommand{
+		TeamID:      "1",
+		TeamName:    "Team 1",
+		ChannelID:   "12345",
+		ChannelName: "Channel 12345",
+		UserID:      "54321",
+		Username:    "User 54321",
+	}
+
+	tests := []struct {
+		name    string
+		acsCtrl model.AccessControl
+		wantErr bool
+	}{
+		{
+			name:    "empty access control must be allowed",
+			acsCtrl: model.AccessControl{},
+			wantErr: false,
+		},
+		{
+			name: "valid team id",
+			acsCtrl: model.AccessControl{
+				TeamID: []string{"1"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid team id",
+			acsCtrl: model.AccessControl{
+				TeamID: []string{"2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid team name",
+			acsCtrl: model.AccessControl{
+				TeamName: []string{"Team 1"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid team name",
+			acsCtrl: model.AccessControl{
+				TeamName: []string{"Team 2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid channel id",
+			acsCtrl: model.AccessControl{
+				ChannelID: []string{"12345"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid channel id",
+			acsCtrl: model.AccessControl{
+				ChannelID: []string{"12346"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid channel name",
+			acsCtrl: model.AccessControl{
+				ChannelName: []string{"Channel 12345"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid channel name",
+			acsCtrl: model.AccessControl{
+				ChannelName: []string{"Channel 12346"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid user id",
+			acsCtrl: model.AccessControl{
+				UserID: []string{"54321"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid user id",
+			acsCtrl: model.AccessControl{
+				UserID: []string{"543210"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid user name",
+			acsCtrl: model.AccessControl{
+				UserName: []string{"User 54321"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid user name",
+			acsCtrl: model.AccessControl{
+				UserName: []string{"User 543210"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid all ids",
+			acsCtrl: model.AccessControl{
+				TeamID:    []string{"1"},
+				ChannelID: []string{"12345"},
+				UserID:    []string{"54321"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "one invalid id",
+			acsCtrl: model.AccessControl{
+				TeamID:    []string{"1"},
+				ChannelID: []string{"wrong"},
+				UserID:    []string{"54321"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid all names",
+			acsCtrl: model.AccessControl{
+				TeamName:    []string{"Team 1"},
+				ChannelName: []string{"Channel 12345"},
+				UserName:    []string{"User 54321"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "one invalid name",
+			acsCtrl: model.AccessControl{
+				TeamName:    []string{"Team 1"},
+				ChannelName: []string{"Channel 12345"},
+				UserName:    []string{"User wrong"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "all valid",
+			acsCtrl: model.AccessControl{
+				TeamID:      []string{"1"},
+				ChannelID:   []string{"12345"},
+				UserID:      []string{"54321"},
+				TeamName:    []string{"Team 1"},
+				ChannelName: []string{"Channel 12345"},
+				UserName:    []string{"User 54321"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SlashCommand{
+				AccessControl: tt.acsCtrl,
+			}
+			if err := s.accessControl(mmSlashCommand); (err != nil) != tt.wantErr {
+				t.Errorf("SlashCommand.accessControl() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
This PR re-add access control but also allows to filter on a team, a channel in addition to users.

Using the multiple command architecture, we can fine-tune who can do what, for example:

```yaml
commands: 
  # no access control but we restrict what is available publicly but exclude some commands from the plugins.
  # note: we could also have used "only" to only allow certain commands.
  - command: jops    
    plugins:
      - name: docker
        exclude: ["run", "exec"]
      - name: gitlab
        exclude: ["tag create"]
  # we can do everything with this slash command but it's restricted to users having access to a specific channel
  - command: jops-private
    plugins:
      - name: docker
      - name: gitlab
    access_control:
        channel_id: ["my-private-channel-id"]
```


#### Ticket Link
N/A

