### PR TITLE
allow injecting env variable in the config (fixes #34)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,6 @@ func Load(ctx context.Context, path string) (*Config, error) {
 
 	// Try to use the config file as a template.
 	// If anything fails at this stage only log error but let the program continue
-	// turns all env variable into template variables
 	log.FromContext(ctx).Debug("parsing config file as template")
 	content = parseConfigTemplate(ctx, content)
 
@@ -87,6 +86,7 @@ func parseConfigTemplate(ctx context.Context, content []byte) []byte {
 		return content
 	}
 
+	// turns all env variable into template variables
 	m := make(map[string]string)
 	for _, e := range os.Environ() {
 		if i := strings.Index(e, "="); i >= 0 {

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -1,6 +1,6 @@
 ---
 
-listen: "0.0.0.0:8080"
+listen: "{{ .Env.MM_OPTOOLS_LISTEN }}"
 base_url: "https://op-tools-address.com"
 plugins:
   - name: bash_useful

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,13 +69,12 @@ commands:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			for varName := range tt.injectEnv {
 				os.Setenv(varName, tt.injectEnv[varName])
 			}
 
 			if got := parseConfigTemplate(context.TODO(), tt.input); !reflect.DeepEqual(got, tt.output) {
-				if len(got) == 0 && len(got) == len(tt.output) {
+				if len(got) == 0 && len(tt.output) == 0 {
 					// valid
 					return
 				}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func Test_parseConfigTemplate(t *testing.T) {
+	tests := []struct {
+		name      string
+		injectEnv map[string]string
+		input     []byte
+		output    []byte
+	}{
+		{
+			name:   "empty",
+			input:  []byte(``),
+			output: []byte(``),
+		},
+		{
+			name: "environment variable must be present",
+			injectEnv: map[string]string{
+				"FOO": "bar",
+			},
+			input:  []byte(`{{ .Env.FOO }}`),
+			output: []byte(`bar`),
+		},
+		{
+			name: "input similar to our config without variables",
+			input: []byte(`
+listen_address: "0.0.0.0:8080"
+commands:
+  - name: jops
+    token: "AbCdEfGhIjKlMnOpQrStUvWxYz"
+	access_control:
+	  user_name: ["user1", "user2"]`),
+			output: []byte(`
+listen_address: "0.0.0.0:8080"
+commands:
+  - name: jops
+    token: "AbCdEfGhIjKlMnOpQrStUvWxYz"
+	access_control:
+	  user_name: ["user1", "user2"]`),
+		},
+		{
+			name: "input similar to our config with variable",
+			injectEnv: map[string]string{
+				"MM_OPTOOLS_LISTEN_ADDRESS":  "0.0.0.0:8080",
+				"MM_CMD_JOPS_TOKEN":          "AbCdEfGhIjKlMnOpQrStUvWxYz",
+				"MM_CMD_JOPS_ACL_USER_NAMES": `["user1", "user2"]`,
+			},
+			input: []byte(`
+listen_address: "{{ .Env.MM_OPTOOLS_LISTEN_ADDRESS }}"
+commands:
+  - name: jops
+    token: "{{ .Env.MM_CMD_JOPS_TOKEN }}"
+	access_control:
+	  user_name: {{ .Env.MM_CMD_JOPS_ACL_USER_NAMES }}`),
+			output: []byte(`
+listen_address: "0.0.0.0:8080"
+commands:
+  - name: jops
+    token: "AbCdEfGhIjKlMnOpQrStUvWxYz"
+	access_control:
+	  user_name: ["user1", "user2"]`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			for varName := range tt.injectEnv {
+				os.Setenv(varName, tt.injectEnv[varName])
+			}
+
+			if got := parseConfigTemplate(context.TODO(), tt.input); !reflect.DeepEqual(got, tt.output) {
+				if len(got) == 0 && len(got) == len(tt.output) {
+					// valid
+					return
+				}
+				t.Errorf("parseConfigTemplate() = %v, want %v", got, tt.output)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -61,7 +61,7 @@ func (s *Server) Start(ctx context.Context, configPath string) error {
 	log.Info("Starting ops tool server...")
 
 	log.Info("Loading config...")
-	cfg, err := config.Load(configPath)
+	cfg, err := config.Load(ctx, configPath)
 	if err != nil {
 		log.WithError(err).Error("Failed to load config")
 		return errors.Wrap(err, "failed to load config")


### PR DESCRIPTION
#### Summary
This PR allows the op-tools sysadmin to inject environment variables in the config file using go templates.

#### Ticket Link
Fixed https://github.com/mattermost/ops-tool/issues/34

